### PR TITLE
Add namespace creation and selfHeal

### DIFF
--- a/admin-cluster/components/applicationsets/develop/all-namespaces-config.yml
+++ b/admin-cluster/components/applicationsets/develop/all-namespaces-config.yml
@@ -23,5 +23,8 @@ spec:
         server: https://kubernetes.default.svc
         namespace: '{{ path[3] }}'
       syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
         automated:
-            prune: true
+          prune: true
+          selfHeal: true

--- a/admin-cluster/components/applicationsets/production/all-namespaces-config.yml
+++ b/admin-cluster/components/applicationsets/production/all-namespaces-config.yml
@@ -23,5 +23,8 @@ spec:
         server: https://kubernetes.default.svc
         namespace: '{{ path[3] }}'
       syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
         automated:
-            prune: true
+          prune: true
+          selfHeal: true

--- a/admin-cluster/components/applicationsets/staging/all-namespaces-config.yml
+++ b/admin-cluster/components/applicationsets/staging/all-namespaces-config.yml
@@ -23,5 +23,8 @@ spec:
         server: https://kubernetes.default.svc
         namespace: '{{ path[3] }}'
       syncPolicy:
+        syncOptions:
+          - CreateNamespace=true
         automated:
-            prune: true
+          prune: true
+          selfHeal: true


### PR DESCRIPTION
Adding automatic namespace creation to applications to let argo create the ns if missing.
`selfHeal` allows argo to revert local changes done outside of git.